### PR TITLE
v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,8 @@
 - README updates.
 - Mainnet contracts now up to date.
 - No longer mocking contract addresses and API URL.
+
+## 1.1.1
+
+- The `placeOrder` method now takes a `priceIncrement` parameter for market orders to ensure correct precision when slippage is applied.
+- Nonces are now generated in microsecond time instead of nanosecond time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "100x-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A TypesScript SDK for the 100x exchange API.",
   "keywords": [
     "100x",

--- a/src/__tests__/client.orders.test.ts
+++ b/src/__tests__/client.orders.test.ts
@@ -22,9 +22,9 @@ describe('The HundredXClient', () => {
       const result = await Client.placeOrder({
         isBuy: true,
         price: 3450,
+        priceIncrement: 100000000000000000n,
         productId: 1002,
         quantity: 0.001,
-        priceIncrement: 100000000000000000n,
       })
       const call = fetchMock.mock.calls[0]
 
@@ -35,7 +35,7 @@ describe('The HundredXClient', () => {
             account: '0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8',
             isBuy: true,
             expiration: 1712421760000n,
-            nonce: 17098297600000000n,
+            nonce: 1709829760000000n,
             orderType: 2,
             price: 3536200000000000000000n,
             productId: 1002,
@@ -52,7 +52,7 @@ describe('The HundredXClient', () => {
         [
           "https://api.staging.100x.finance/v1/order",
           {
-            "body": "{"expiration":1712421760000,"nonce":17098297600000000,"price":"3536200000000000000000","quantity":"1000000000000000","signature":"0x023a709b408126f6e3d8bf6e389ddb30eaca51921df2531c8cc75a86b1daa229264cd326a5b3051984875740cdf549d4df4cdfd2384caea8a23aa6af80d1e53a1b","account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","isBuy":true,"orderType":2,"productId":1002,"subAccountId":1,"timeInForce":1}",
+            "body": "{"expiration":1712421760000,"nonce":1709829760000000,"price":"3536200000000000000000","quantity":"1000000000000000","signature":"0x8c78e174166913aeee11b427169e1a33ba6ecd06dbdccc1fd60da4e33b8ce0a01e17d420110bbb5bd07af7d8ae19b83a443cab3885f20a863d262014f3e1ce481b","account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","isBuy":true,"orderType":2,"productId":1002,"subAccountId":1,"timeInForce":1}",
             "method": "POST",
           },
         ]
@@ -62,7 +62,7 @@ describe('The HundredXClient', () => {
       })
     })
 
-    it('should allow a user to successfully place an order with all args passed', async () => {
+    it('should allow a user to successfully place an order with all args passed (limit order)', async () => {
       fetchMock.mockResponse(JSON.stringify(customOrder))
 
       const Client = new HundredXClient(privateKey)
@@ -468,7 +468,7 @@ describe('The HundredXClient', () => {
             account: '0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8',
             isBuy: true,
             expiration: 1712421760000n,
-            nonce: 17098297600000000n,
+            nonce: 1709829760000000n,
             orderType: 1,
             price: 3455000000000000000000n,
             productId: 1002,
@@ -485,7 +485,7 @@ describe('The HundredXClient', () => {
         [
           "https://api.staging.100x.finance/v1/order/cancel-and-replace",
           {
-            "body": "{"idToCancel":"0x08d4079c501e5fbb2153c7fe785ea4648ffcdac411d93511edcb5b18aecc158f","newOrder":{"expiration":1712421760000,"nonce":17098297600000000,"price":"3455000000000000000000","quantity":"1000000000000000","signature":"0x6a076f90627354d3d58647d6f53aaf7f75aaf7539f51112176efccc3f6e370fb7fd28aa4f8c9075b8c5f1454958286b585bfb532123608430623264abb8bf76b1c","account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","isBuy":true,"orderType":1,"productId":1002,"subAccountId":1,"timeInForce":0}}",
+            "body": "{"idToCancel":"0x08d4079c501e5fbb2153c7fe785ea4648ffcdac411d93511edcb5b18aecc158f","newOrder":{"expiration":1712421760000,"nonce":1709829760000000,"price":"3455000000000000000000","quantity":"1000000000000000","signature":"0x6438968d739df7ffade1aa28d03d0ebbd8c3297134402d02fdbcd9f69bdf1ee80525712e93012093329f0ac55226992a4699973de59ca687a91258054dbbc8d21c","account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","isBuy":true,"orderType":1,"productId":1002,"subAccountId":1,"timeInForce":0}}",
             "method": "POST",
           },
         ]

--- a/src/__tests__/client.setters.test.ts
+++ b/src/__tests__/client.setters.test.ts
@@ -14,6 +14,7 @@ describe('The HundredXClient', () => {
     await Client.placeOrder({
       isBuy: true,
       price: 3450,
+      priceIncrement: 100000000000000000n,
       productId: 1002,
       quantity: 0.001,
     })
@@ -27,6 +28,7 @@ describe('The HundredXClient', () => {
     await Client.placeOrder({
       isBuy: true,
       price: 3450,
+      priceIncrement: 100000000000000000n,
       productId: 1002,
       quantity: 0.001,
     })

--- a/src/__tests__/client.withdraw.test.ts
+++ b/src/__tests__/client.withdraw.test.ts
@@ -26,7 +26,7 @@ describe('The HundredXClient withdraw function', () => {
           account: '0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8',
           asset: USDB,
           subAccountId: 1,
-          nonce: 17098297600000000n,
+          nonce: 1709829760000000n,
           quantity: 100000000000000000000n,
         },
         primaryType: 'Withdraw',
@@ -38,7 +38,7 @@ describe('The HundredXClient withdraw function', () => {
       [
         "https://api.staging.100x.finance/v1/withdraw",
         {
-          "body": "{"account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","asset":"0x79a59c326c715ac2d31c169c85d1232319e341ce","subAccountId":1,"nonce":17098297600000000,"quantity":"100000000000000000000","signature":"0x03e35e3d0557f7a14f7631b699f7253449882705642e51debacd08df78bf03843419e37d4ce776cf319fc022277ea861fc229b14f42d03ebb18d094ccb2b22ff1c"}",
+          "body": "{"account":"0xb47B0b1e44B932Ae9Bb01817E7010A553A965Ea8","asset":"0x79a59c326c715ac2d31c169c85d1232319e341ce","subAccountId":1,"nonce":1709829760000000,"quantity":"100000000000000000000","signature":"0x85b5663e45bdf5ac66d23741b67a0fea118c93c38c98099abaebac21607475ed15ff4d3287c178b90f219eb3b2f9e3e7b940a18da6d3bb76b2ae6783976374791b"}",
           "method": "POST",
         },
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,13 +150,21 @@ class HundredXClient {
    * @param isBuy Whether to buy (true) or sell (false).
    * @param price The price of the order.
    * @param slippage The percentage by which to adjust the price.
+   * @param priceIncrement The precision the price should be rounded to.
+   * This value can be found under the `increment` key when calling the `getProduct` method.
    * @returns A new price number adjusted by the specified slippage.
    */
-  #adjustPriceForSlippage = (isBuy: boolean, price: number, slippage: number) => {
+  #adjustPriceForSlippage = (
+    isBuy: boolean,
+    price: number,
+    slippage: number,
+    priceIncrement: bigint,
+  ) => {
     const slippagePercentage = slippage / 100
     const multiplier = isBuy ? 1 + slippagePercentage : 1 - slippagePercentage
+    const precision = 18 - Math.log10(Number(priceIncrement))
 
-    return toRounded(price * multiplier)
+    return toRounded(price * multiplier, precision)
   }
 
   /**
@@ -980,6 +988,8 @@ class HundredXClient {
    * @param [orderArgs.nonce] (Optional) A unique identifier for the order. (default: current unix timestamp in nano seconds).
    * @param [orderArgs.orderType] (Optional) The type of order (default: market). Use the {@link OrderType} enum.
    * @param orderArgs.price The price of the order.
+   * @param [orderArgs.priceIncrement] The price precision for the product. This is only required for MARKET orders.
+   * This value can be found under the `increment` key when calling the `getProduct` method.
    * @param orderArgs.productId The product identifier for the order.
    * @param orderArgs.quantity The quantity of the order.
    * @param [orderArgs.timeInForce] (Optional) The time in force for the order (default: FOK). Use the {@link TimeInForce} enum.
@@ -993,14 +1003,24 @@ class HundredXClient {
     nonce = this.#getNonce(),
     orderType = OrderType.MARKET,
     price,
+    priceIncrement,
     productId,
     quantity,
     slippage = 2.5,
     timeInForce = TimeInForce.FOK,
   }: OrderArgs): Promise<PlaceOrderReturnType> => {
+    if (orderType === OrderType.MARKET && priceIncrement === undefined) {
+      return {
+        error: { message: 'A priceIncrement is required for market orders' },
+        order: {},
+      }
+    }
+
     const bigPrice =
       orderType === OrderType.MARKET
-        ? this.#toWei(this.#adjustPriceForSlippage(isBuy, price, slippage))
+        ? this.#toWei(
+            this.#adjustPriceForSlippage(isBuy, price, slippage, priceIncrement as bigint),
+          )
         : this.#toWei(price)
     const bigQuantity = this.#toWei(quantity)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,9 +243,9 @@ class HundredXClient {
   /**
    * Generates a nonce.
    *
-   * @returns The current timestamp in nanoseconds.
+   * @returns The current timestamp in microseconds.
    */
-  #getNonce = (): number => Math.floor((Date.now() + performance.now()) * 10000)
+  #getNonce = (): number => Math.floor((Date.now() + performance.now()) * 1000)
 
   /**
    * Private method to refer the user on class initialisation.

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ interface OrderArgs {
   nonce?: number
   orderType?: OrderType
   price: number
+  priceIncrement?: bigint
   productId: number
   quantity: number
   slippage?: number

--- a/vitest/utils.ts
+++ b/vitest/utils.ts
@@ -186,7 +186,7 @@ export const marketFOKOrder = {
   isBuy: true,
   orderType: 2,
   timeInForce: 1,
-  price: '3450000000000000000000',
+  price: '3536200000000000000000',
   quantity: '1000000000000000',
   nonce: 1712421760000,
   sender: address,
@@ -202,6 +202,7 @@ export const customOrder = {
   ...marketFOKOrder,
   orderType: 0,
   timeInForce: 2,
+  price: '3450000000000000000000',
   nonce: 123,
   expiry: 1800000000000,
 }


### PR DESCRIPTION
## Description

- The `placeOrder` method now takes a `priceIncrement` parameter for market orders to ensure correct precision when slippage is applied.
- Nonces are now generated in microsecond time instead of nanosecond time.

## Code Checklist

- [x] Includes tests (where applicable)
- [x] Includes documentation (where applicable)

## Review Checklist

- [x] I have successfully run a build.
- [x] I have confirmed my tests are passing.
- [x] I have rebased from master and have no conflicts.
- [x] I have bumped the version number and added an entry to the change log.
